### PR TITLE
Base headings on modular scales

### DIFF
--- a/typographic.scss
+++ b/typographic.scss
@@ -148,8 +148,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  $min-font: $min-font + _pow($ratio, 12);
-  $max-font: $max-font + _pow($ratio, 12);
+  $min-font: $min-font * _pow($ratio, 12);
+  $max-font: $max-font * _pow($ratio, 12);
 
   font-size: $min-font;
 
@@ -163,8 +163,8 @@ h1 {
 }
 
 h2 {
-  $min-font: $min-font + _pow($ratio, 10);
-  $max-font: $max-font + _pow($ratio, 10);
+  $min-font: $min-font * _pow($ratio, 10);
+  $max-font: $max-font * _pow($ratio, 10);
 
   font-size: $min-font;
 
@@ -178,8 +178,8 @@ h2 {
 }
 
 h3 {
-  $min-font: $min-font + _pow($ratio, 8);
-  $max-font: $max-font + _pow($ratio, 8);
+  $min-font: $min-font * _pow($ratio, 8);
+  $max-font: $max-font * _pow($ratio, 8);
 
   font-size: $min-font;
 
@@ -193,8 +193,8 @@ h3 {
 }
 
 h4 {
-  $min-font: $min-font + _pow($ratio, 6);
-  $max-font: $max-font + _pow($ratio, 6);
+  $min-font: $min-font * _pow($ratio, 6);
+  $max-font: $max-font * _pow($ratio, 6);
 
   font-size: $min-font;
 
@@ -208,8 +208,8 @@ h4 {
 }
 
 h5 {
-  $min-font: $min-font + _pow($ratio, 4);
-  $max-font: $max-font + _pow($ratio, 4);
+  $min-font: $min-font * _pow($ratio, 4);
+  $max-font: $max-font * _pow($ratio, 4);
 
   font-size: $min-font;
 
@@ -223,8 +223,8 @@ h5 {
 }
 
 h6 {
-  $min-font: $min-font + _pow($ratio, 2);
-  $max-font: $max-font + _pow($ratio, 2);
+  $min-font: $min-font * _pow($ratio, 2);
+  $max-font: $max-font * _pow($ratio, 2);
 
   font-size: $min-font;
 

--- a/typographic.scss
+++ b/typographic.scss
@@ -78,6 +78,18 @@ $max-width          : 1000px;
   @return $number / ($number * 0 + 1);
 }
 
+@function _pow($number,$power) {
+  $return: 1;
+  @for $i from 0 to $power {
+    @if $power > 0 {
+      $return: $return * $number;
+    } @else {
+      $return: $return / $number;
+    }
+  }
+  @return $return;
+}
+
 
 // Functionality
 
@@ -136,8 +148,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  $min-font: $min-font + $ratio * 12;
-  $max-font: $max-font + $ratio * 12;
+  $min-font: $min-font + _pow($ratio, 12);
+  $max-font: $max-font + _pow($ratio, 12);
 
   font-size: $min-font;
 
@@ -151,8 +163,8 @@ h1 {
 }
 
 h2 {
-  $min-font: $min-font + $ratio * 10;
-  $max-font: $max-font + $ratio * 10;
+  $min-font: $min-font + _pow($ratio, 10);
+  $max-font: $max-font + _pow($ratio, 10);
 
   font-size: $min-font;
 
@@ -166,8 +178,8 @@ h2 {
 }
 
 h3 {
-  $min-font: $min-font + $ratio * 8;
-  $max-font: $max-font + $ratio * 8;
+  $min-font: $min-font + _pow($ratio, 8);
+  $max-font: $max-font + _pow($ratio, 8);
 
   font-size: $min-font;
 
@@ -181,8 +193,8 @@ h3 {
 }
 
 h4 {
-  $min-font: $min-font + $ratio * 6;
-  $max-font: $max-font + $ratio * 6;
+  $min-font: $min-font + _pow($ratio, 6);
+  $max-font: $max-font + _pow($ratio, 6);
 
   font-size: $min-font;
 
@@ -196,8 +208,8 @@ h4 {
 }
 
 h5 {
-  $min-font: $min-font + $ratio * 4;
-  $max-font: $max-font + $ratio * 4;
+  $min-font: $min-font + _pow($ratio, 4);
+  $max-font: $max-font + _pow($ratio, 4);
 
   font-size: $min-font;
 
@@ -211,8 +223,8 @@ h5 {
 }
 
 h6 {
-  $min-font: $min-font + $ratio * 2;
-  $max-font: $max-font + $ratio * 2;
+  $min-font: $min-font + _pow($ratio, 2);
+  $max-font: $max-font + _pow($ratio, 2);
 
   font-size: $min-font;
 

--- a/typographic.styl
+++ b/typographic.styl
@@ -123,8 +123,8 @@ h1, h2, h3, h4, h5, h6
   color: $header-color
 
 h1
-  $min-font = $min-font + ($ratio ** 12)
-  $max-font = $max-font + ($ratio ** 12)
+  $min-font = $min-font * ($ratio ** 12)
+  $max-font = $max-font * ($ratio ** 12)
 
   font-size: $min-font
 
@@ -135,8 +135,8 @@ h1
     font-size: $max-font
 
 h2
-  $min-font = $min-font + ($ratio ** 10)
-  $max-font = $max-font + ($ratio ** 10)
+  $min-font = $min-font * ($ratio ** 10)
+  $max-font = $max-font * ($ratio ** 10)
 
   font-size: $min-font
 
@@ -147,8 +147,8 @@ h2
     font-size: $max-font
 
 h3
-  $min-font = $min-font + ($ratio ** 8)
-  $max-font = $max-font + ($ratio ** 8)
+  $min-font = $min-font * ($ratio ** 8)
+  $max-font = $max-font * ($ratio ** 8)
 
   font-size: $min-font
 
@@ -159,8 +159,8 @@ h3
     font-size: $max-font
 
 h4
-  $min-font = $min-font + ($ratio ** 6)
-  $max-font = $max-font + ($ratio ** 6)
+  $min-font = $min-font * ($ratio ** 6)
+  $max-font = $max-font * ($ratio ** 6)
 
   font-size: $min-font
 
@@ -171,8 +171,8 @@ h4
     font-size: $max-font
 
 h5
-  $min-font = $min-font + ($ratio ** 4)
-  $max-font = $max-font + ($ratio ** 4)
+  $min-font = $min-font * ($ratio ** 4)
+  $max-font = $max-font * ($ratio ** 4)
 
   font-size: $min-font
 
@@ -183,8 +183,8 @@ h5
     font-size: $max-font
 
 h6
-  $min-font = $min-font + ($ratio ** 2)
-  $max-font = $max-font + ($ratio ** 2)
+  $min-font = $min-font * ($ratio ** 2)
+  $max-font = $max-font * ($ratio ** 2)
 
   font-size: $min-font
 

--- a/typographic.styl
+++ b/typographic.styl
@@ -123,8 +123,8 @@ h1, h2, h3, h4, h5, h6
   color: $header-color
 
 h1
-  $min-font = $min-font + $ratio * 12
-  $max-font = $max-font + $ratio * 12
+  $min-font = $min-font + ($ratio ** 12)
+  $max-font = $max-font + ($ratio ** 12)
 
   font-size: $min-font
 
@@ -135,8 +135,8 @@ h1
     font-size: $max-font
 
 h2
-  $min-font = $min-font + $ratio * 10
-  $max-font = $max-font + $ratio * 10
+  $min-font = $min-font + ($ratio ** 10)
+  $max-font = $max-font + ($ratio ** 10)
 
   font-size: $min-font
 
@@ -147,8 +147,8 @@ h2
     font-size: $max-font
 
 h3
-  $min-font = $min-font + $ratio * 8
-  $max-font = $max-font + $ratio * 8
+  $min-font = $min-font + ($ratio ** 8)
+  $max-font = $max-font + ($ratio ** 8)
 
   font-size: $min-font
 
@@ -159,8 +159,8 @@ h3
     font-size: $max-font
 
 h4
-  $min-font = $min-font + $ratio * 6
-  $max-font = $max-font + $ratio * 6
+  $min-font = $min-font + ($ratio ** 6)
+  $max-font = $max-font + ($ratio ** 6)
 
   font-size: $min-font
 
@@ -171,8 +171,8 @@ h4
     font-size: $max-font
 
 h5
-  $min-font = $min-font + $ratio * 4
-  $max-font = $max-font + $ratio * 4
+  $min-font = $min-font + ($ratio ** 4)
+  $max-font = $max-font + ($ratio ** 4)
 
   font-size: $min-font
 
@@ -183,8 +183,8 @@ h5
     font-size: $max-font
 
 h6
-  $min-font = $min-font + $ratio * 2
-  $max-font = $max-font + $ratio * 2
+  $min-font = $min-font + ($ratio ** 2)
+  $max-font = $max-font + ($ratio ** 2)
 
   font-size: $min-font
 


### PR DESCRIPTION
###### What this PR does:

Aligns the headings to a modular scale. Modular scales are exponential functions so I changed all headings to follow the proper formula. The formula for modular scalse is `(ratio^value)*base`.

Additionally, Sass doesn’t natively have exponents so I added a `_pow()` function.
###### What this PR is not:

I did not tweak the sizes to look correct with the new formula. You’ll probably need to tune the values down, or the default ratio down. Double stranded scales is a common solve to make the curve a little shallower but that introduces a lot more complexity.
