### PR TITLE
Removed unnecessary margin-bottom from <a> element & fixed header line-height

### DIFF
--- a/scss/typographic.scss
+++ b/scss/typographic.scss
@@ -213,7 +213,7 @@ $max-width          : 1000px !default;
 
   p, blockquote, pre,
   address,
-  a, code,
+  code,
   dl, ol, ul,
   form,
   table {

--- a/scss/typographic.scss
+++ b/scss/typographic.scss
@@ -233,7 +233,7 @@ $max-width          : 1000px !default;
     $local-max-font: $max-font * (math-pow($header-ratio, 1.75));
 
     font-size: $local-min-font;
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2)) + em;
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5)) + em;
 
     @media (min-width: $min-width) {
       font-size: calc( #{$local-min-font} + (#{_strip-units($local-max-font)} - #{_strip-units($local-min-font)}) * ((100vw - #{$min-width}) / (#{_strip-units($max-width)} - #{_strip-units($min-width)})) );
@@ -250,7 +250,7 @@ $max-width          : 1000px !default;
     $local-max-font: $max-font * (math-pow($header-ratio, 1.4));
 
     font-size: $local-min-font;
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2)) + em;
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5)) + em;
 
     @media (min-width: $min-width) {
       font-size: calc( #{$local-min-font} + (#{_strip-units($local-max-font)} - #{_strip-units($local-min-font)}) * ((100vw - #{$min-width}) / (#{_strip-units($max-width)} - #{_strip-units($min-width)})) );
@@ -267,7 +267,7 @@ $max-width          : 1000px !default;
     $local-max-font: $max-font * (math-pow($header-ratio, 1.05));
 
     font-size: $local-min-font;
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2)) + em;
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5)) + em;
 
     @media (min-width: $min-width) {
       font-size: calc( #{$local-min-font} + (#{_strip-units($local-max-font)} - #{_strip-units($local-min-font)}) * ((100vw - #{$min-width}) / (#{_strip-units($max-width)} - #{_strip-units($min-width)})) );
@@ -284,7 +284,7 @@ $max-width          : 1000px !default;
     $local-max-font: $max-font * (math-pow($header-ratio, .7));
 
     font-size: $local-min-font;
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2)) + em;
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5)) + em;
 
     @media (min-width: $min-width) {
       font-size: calc( #{$local-min-font} + (#{_strip-units($local-max-font)} - #{_strip-units($local-min-font)}) * ((100vw - #{$min-width}) / (#{_strip-units($max-width)} - #{_strip-units($min-width)})) );
@@ -301,7 +301,7 @@ $max-width          : 1000px !default;
     $local-max-font: $max-font * (math-pow($header-ratio, .35));
 
     font-size: $local-min-font;
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2)) + em;
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5)) + em;
 
     @media (min-width: $min-width) {
       font-size: calc( #{$local-min-font} + (#{_strip-units($local-max-font)} - #{_strip-units($local-min-font)}) * ((100vw - #{$min-width}) / (#{_strip-units($max-width)} - #{_strip-units($min-width)})) );
@@ -318,7 +318,7 @@ $max-width          : 1000px !default;
     $local-max-font: $max-font;
 
     font-size: $local-min-font;
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2)) + em;
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5)) + em;
 
     @media (min-width: $min-width) {
       font-size: calc( #{$local-min-font} + (#{_strip-units($local-max-font)} - #{_strip-units($local-min-font)}) * ((100vw - #{$min-width}) / (#{_strip-units($max-width)} - #{_strip-units($min-width)})) );

--- a/stylus/typographic.styl
+++ b/stylus/typographic.styl
@@ -120,7 +120,7 @@ typographic()
 
   p, blockquote, pre,
   address,
-  a, code,
+  code,
   dl, ol, ul,
   form,
   table

--- a/stylus/typographic.styl
+++ b/stylus/typographic.styl
@@ -119,8 +119,7 @@ typographic()
     padding: 0
 
   p, blockquote, pre,
-  address,
-  code,
+  address, code,
   dl, ol, ul,
   form,
   table
@@ -138,84 +137,84 @@ typographic()
     $local-max-font = $max-font * ($header-ratio ** 1.75)
 
     font-size: $local-min-font
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2))em
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5))em
 
     @media (min-width: $min-width)
       font-size: s('calc( %s + (%s - %s) * ((100vw - %s) / (%s - %s)) )', $local-min-font, remove-unit($local-max-font), remove-unit($local-min-font), $min-width, remove-unit($max-width), remove-unit($min-width))
 
     @media (min-width: $max-width)
       font-size: $local-max-font
-      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 2))em
+      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 1.5))em
 
   h2
     $local-min-font = $min-font * ($header-ratio ** 1.4)
     $local-max-font = $max-font * ($header-ratio ** 1.4)
 
     font-size: $local-min-font
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2))em
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5))em
 
     @media (min-width: $min-width)
       font-size: s('calc( %s + (%s - %s) * ((100vw - %s) / (%s - %s)) )', $local-min-font, remove-unit($local-max-font), remove-unit($local-min-font), $min-width, remove-unit($max-width), remove-unit($min-width))
 
     @media (min-width: $max-width)
       font-size: $local-max-font
-      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 2))em
+      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 1.5))em
 
   h3
     $local-min-font = $min-font * ($header-ratio ** 1.05)
     $local-max-font = $max-font * ($header-ratio ** 1.05)
 
     font-size: $local-min-font
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2))em
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5))em
 
     @media (min-width: $min-width)
       font-size: s('calc( %s + (%s - %s) * ((100vw - %s) / (%s - %s)) )', $local-min-font, remove-unit($local-max-font), remove-unit($local-min-font), $min-width, remove-unit($max-width), remove-unit($min-width))
 
     @media (min-width: $max-width)
       font-size: $local-max-font
-      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 2))em
+      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 1.5))em
 
   h4
     $local-min-font = $min-font * ($header-ratio ** .7)
     $local-max-font = $max-font * ($header-ratio ** .7)
 
     font-size: $local-min-font
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2))em
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5))em
 
     @media (min-width: $min-width)
       font-size: s('calc( %s + (%s - %s) * ((100vw - %s) / (%s - %s)) )', $local-min-font, remove-unit($local-max-font), remove-unit($local-min-font), $min-width, remove-unit($max-width), remove-unit($min-width))
 
     @media (min-width: $max-width)
       font-size: $local-max-font
-      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 2))em
+      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 1.5))em
 
   h5
     $local-min-font = $min-font * ($header-ratio ** .35)
     $local-max-font = $max-font * ($header-ratio ** .35)
 
     font-size: $local-min-font
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2))em
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5))em
 
     @media (min-width: $min-width)
       font-size: s('calc( %s + (%s - %s) * ((100vw - %s) / (%s - %s)) )', $local-min-font, remove-unit($local-max-font), remove-unit($local-min-font), $min-width, remove-unit($max-width), remove-unit($min-width))
 
     @media (min-width: $max-width)
       font-size: $local-max-font
-      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 2))em
+      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 1.5))em
 
   h6
     $local-min-font = $min-font
     $local-max-font = $max-font
 
     font-size: $local-min-font
-    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 2))em
+    line-height: (($line-height-ratio * $min-font) / ($local-min-font / 1.5))em
 
     @media (min-width: $min-width)
       font-size: s('calc( %s + (%s - %s) * ((100vw - %s) / (%s - %s)) )', $local-min-font, remove-unit($local-max-font), remove-unit($local-min-font), $min-width, remove-unit($max-width), remove-unit($min-width))
 
     @media (min-width: $max-width)
       font-size: $local-max-font
-      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 2))em
+      line-height: (($line-height-ratio * $max-font) / ($local-max-font / 1.5))em
 
   blockquote
     font-style: italic


### PR DESCRIPTION
**[Removed unnecessary margin-bottom from `<a>` element](https://github.com/flip4bytes/typographic/commit/9cad62800dfefff3f24b6e3e602745b6129a32ce)**

`<a>` is pretty much always going to be a child of a `<p>`  `<blockquote>` `<ul>` `<ol>`, etc. so giving `<a>` it's own separate margin bottom just seems really wrong.

Please let me know if there's a big reason as to why you did this. My site got pretty messed up over this and by removing it everything was fixed. I just don't see why margin-bottom of line-height-ratio would ever be needed as a base style on `<a>` elements.. Like ever.

---

**[Reduced the amount of line-height that header elements have](https://github.com/flip4bytes/typographic/commit/0679e617b6afe649a2ae7676edfbd014dfb830e4)**

Here are 2 **BEFORE** pictures (the smaller the screen, the worse it gets)
![](http://i.imgur.com/ru7w2Vz.jpg) ![](https://s3.amazonaws.com/f.cl.ly/items/2L403d1E0N3E1m2G3f37/Image%202015-03-26%20at%207.07.21%20AM.png)

And here is an **AFTER** (Close enough to still feel grouped but not crowded)
![](https://s3.amazonaws.com/f.cl.ly/items/3D0V2b0S3m3o2L0x1H0L/Image%202015-03-26%20at%207.34.28%20AM.png)

Here is another **BEFORE** & **AFTER** showing off an even bigger difference when having more bolded fonts
![](https://s3.amazonaws.com/f.cl.ly/items/271O2M020q080J3A1o3t/Image%202015-03-26%20at%207.08.54%20AM.png) ![](http://i.imgur.com/rWCP21B.jpg)

Cheers!
