### PR TITLE
Fix deprecation warning

### DIFF
--- a/scss/typographic.scss
+++ b/scss/typographic.scss
@@ -184,7 +184,7 @@ $vertical-rhythm     : true !default;
   $sum: 0;
 
   @for $index from $initial to $limit {
-    $sum: $sum + call($iteratee, $input, $index);
+    $sum: $sum + call(get-function($iteratee), $input, $index);
   }
 
   @return $sum;


### PR DESCRIPTION
Added get-function to call to remove deprecation warning on passing a string to call()